### PR TITLE
feat: Support Removing Headers in Any Case

### DIFF
--- a/src/model/Spec.ts
+++ b/src/model/Spec.ts
@@ -291,7 +291,7 @@ export default class Spec {
 
   private filterHeaderParameters = (parameters: Value, headersToRemove: string[]) => {
     return parameters.filter(
-      (parameter: Record<Key, Value>) => parameter.in !== HEADER || !headersToRemove.includes(parameter.name)
+      (parameter: Record<Key, Value>) => parameter.in !== HEADER || !this.includesIgnoreCase(headersToRemove, parameter.name)
     );
   };
 
@@ -299,7 +299,7 @@ export default class Spec {
   private filterHeaderComponents = (component: Value, headersToRemove: string[]) => {
     const parts = component['$ref'].match(/#\/components\/(.*)\/(.*)/);
     const parameter = this.specs.components[parts?.[1]][parts?.[2]] ?? {};
-    return parameter?.in === HEADER && headersToRemove.includes(parameter.name) ? {} : component;
+    return parameter?.in === HEADER && this.includesIgnoreCase(headersToRemove, parameter.name) ? {} : component;
   };
 
   private mapTags = (tags: string[]): TagObject[] => tags.map((tag) => ({ name: tag }));
@@ -309,5 +309,9 @@ export default class Spec {
   private extractPrefix = (servers: ServerObject[]): string => {
     const server = servers[0];
     return new URL(server.url).pathname;
+  };
+
+  private includesIgnoreCase = (strings: string[], goal: string): boolean => {
+    return strings.includes(goal.toLowerCase());
   };
 }

--- a/test/transformer/HeaderRemovalTransformer.test.ts
+++ b/test/transformer/HeaderRemovalTransformer.test.ts
@@ -31,6 +31,13 @@ describe('test HeaderRemovalTransformer', () => {
       type: 'string',
     },
   };
+  const acceptEncodingCapitalizedHeader = {
+    in: 'header',
+    name: 'Accept-Encoding',
+    schema: {
+      type: 'string',
+    },
+  };
   const authorizationHeader = {
     in: 'header',
     name: 'authorization',
@@ -81,6 +88,7 @@ describe('test HeaderRemovalTransformer', () => {
           parameters: [
             acceptHeader,
             acceptEncodingHeader,
+            acceptEncodingCapitalizedHeader,
             authorizationHeader,
             contentTypeHeader,
             userAgentHeader,
@@ -140,6 +148,7 @@ describe('test HeaderRemovalTransformer', () => {
 
     expect(transformedSpecs.paths['/hello'].get.parameters).toEqual([
       acceptEncodingHeader,
+      acceptEncodingCapitalizedHeader,
       authorizationHeader,
       userAgentHeader,
       xCustomHeader,
@@ -157,6 +166,7 @@ describe('test HeaderRemovalTransformer', () => {
     expect(transformer.transform(specs).paths['/hello'].get.parameters).toEqual([
       acceptHeader,
       acceptEncodingHeader,
+      acceptEncodingCapitalizedHeader,
       authorizationHeader,
       contentTypeHeader,
       userAgentHeader,


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.
