### PR TITLE
feat: Allow parsing of YAML wrongly-indented multiline strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@expediagroup/spec-transformer",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@expediagroup/spec-transformer",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "11.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "commander": "11.0.0",
         "js-yaml": "4.1.0",
         "openapi-to-postmanv2": "4.15.0",
-        "openapi3-ts": "3.2.0",
-        "yaml": "2.3.1"
+        "openapi3-ts": "3.2.0"
       },
       "bin": {
         "cli": "cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expediagroup/spec-transformer",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "API Spec Transformer",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "commander": "11.0.0",
     "js-yaml": "4.1.0",
     "openapi-to-postmanv2": "4.15.0",
-    "openapi3-ts": "3.2.0",
-    "yaml": "2.3.1"
+    "openapi3-ts": "3.2.0"
   },
   "devDependencies": {
     "@semantic-release/changelog": "6.0.3",

--- a/src/io/reader/YamlReader.ts
+++ b/src/io/reader/YamlReader.ts
@@ -16,7 +16,7 @@
 
 import Reader from './Reader';
 import { Key, Value } from '../../model/Types';
-import { parse } from 'yaml';
+import { load } from "js-yaml";
 
 /**
  * A reader implementation for reading the specs in YAML format.
@@ -25,6 +25,6 @@ export class YamlReader implements Reader {
   read(specs: string): Record<Key, Value> {
     if (specs === undefined || specs === null || specs === '') return {};
 
-    return parse(specs);
+    return load(specs) as Record<Key, Value>
   }
 }

--- a/test/io/reader/YamlReader.test.ts
+++ b/test/io/reader/YamlReader.test.ts
@@ -110,6 +110,37 @@ describe('test YamlReader', () => {
     });
   });
 
+  it('should return the parsed specs when they contain wrongly-indented, multiline strings with backslashes', () => {
+    const yamlSpecs =
+      'openapi: 3.0.0\n' +
+      'info:\n' +
+      '  title: Pet Store API\n' +
+      '  version: 1.0.0\n' +
+      'paths:\n' +
+      '  /pets:\n' +
+      '    get:\n' +
+      '      summary: List all pets\n' +
+      '      description: "this is a wrongly\\\n' +
+      '      \\ indented multiline string that\\\n' +
+      '      \\ should be parsed correctly"';
+
+    expect(new YamlReader().read(yamlSpecs)).toEqual({
+      openapi: '3.0.0',
+      info: {
+        title: 'Pet Store API',
+        version: '1.0.0'
+      },
+      paths: {
+        '/pets': {
+          get: {
+            summary: 'List all pets',
+            description: 'this is a wrongly indented multiline string that should be parsed correctly'
+          }
+        }
+      }
+    });
+  });
+
   it('should return an empty record when input is empty', () => {
     expect(new YamlReader().read('')).toEqual({});
   });

--- a/test/io/reader/YamlReader.test.ts
+++ b/test/io/reader/YamlReader.test.ts
@@ -79,6 +79,37 @@ describe('test YamlReader', () => {
     });
   });
 
+  it('should return the parsed specs when they contain wrongly-indented, multiline strings', () => {
+    const yamlSpecs =
+      'openapi: 3.0.0\n' +
+      'info:\n' +
+      '  title: Pet Store API\n' +
+      '  version: 1.0.0\n' +
+      'paths:\n' +
+      '  /pets:\n' +
+      '    get:\n' +
+      '      summary: List all pets\n' +
+      '      description: "this is a wrongly\n' +
+      '      indented multiline string that\n' +
+      '      should be parsed correctly"';
+
+    expect(new YamlReader().read(yamlSpecs)).toEqual({
+      openapi: '3.0.0',
+      info: {
+        title: 'Pet Store API',
+        version: '1.0.0'
+      },
+      paths: {
+        '/pets': {
+          get: {
+            summary: 'List all pets',
+            description: 'this is a wrongly indented multiline string that should be parsed correctly'
+          }
+        }
+      }
+    });
+  });
+
   it('should return an empty record when input is empty', () => {
     expect(new YamlReader().read('')).toEqual({});
   });


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

### :pencil: Description
- Allow parsing of YAML wrongly-indented multiline strings

### :link: Related Issues
N/A
