### PR TITLE
fix(ci): switch to npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GIT_AUTHOR_NAME: eg-oss-ci
           GIT_AUTHOR_EMAIL: oss@expediagroup.com
           GIT_COMMITTER_NAME: eg-oss-ci


### PR DESCRIPTION
## Summary
- Removed `NPM_TOKEN` secret from release workflow
- npm trusted publishing (OIDC) is now configured for this package on npmjs.org
- The existing `id-token: write` permission enables OIDC auth, eliminating the need for static npm tokens

## Context
Classic npm tokens were revoked org-wide in Dec 2025. The active EG OSS npm packages were migrated to trusted publishing, but `spec-transformer` was missed. It has now been linked on npmjs.org.

## Verification
- [ ] semantic-release passes the verifyConditions step
- [ ] Package publishes to npmjs.org
- [ ] GitHub release is created

Generated with [Claude Code](https://claude.com/claude-code)