### PR TITLE
fix(ci): configure npm trusted publishing with OIDC provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Build
         run: npm run build && cd dist && ls -la
 
+      - name: Configure npm for trusted publishing
+        run: echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" > dist/.npmrc
+
       - name: Release
         env:
           GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -58,7 +58,7 @@
         "changelogFile": "CHANGELOG.md"
       }
     ],
-    "@semantic-release/npm",
+    ["@semantic-release/npm", { "provenance": true }],
     "@semantic-release/github",
     [
       "@semantic-release/exec",


### PR DESCRIPTION
## Summary
- Add `.npmrc` in `dist/` to satisfy `@semantic-release/npm` v12 auth verification
- Enable `provenance: true` in `@semantic-release/npm` plugin config
- npm OIDC trusted publishing handles actual authentication at publish time

## Why
The previous PR (#382) removed `NPM_TOKEN` but `@semantic-release/npm` v12 still hard-checks for npm auth in its `verifyConditions` step before OIDC kicks in. This `.npmrc` satisfies that check, and the actual publish uses OIDC via `id-token: write`.

## Verification
- [ ] semantic-release passes verifyConditions
- [ ] Package publishes to npmjs.org with provenance
- [ ] GitHub release is created

Generated with [Claude Code](https://claude.com/claude-code)