### PR TITLE
fix(release): add @semantic-release/npm@12 for OIDC provenance support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           working_directory: dist
           extra_plugins: |
+            @semantic-release/npm@12
             @semantic-release/changelog@6
             @semantic-release/git@10
             @semantic-release/exec@7


### PR DESCRIPTION
## Summary
- Adds `@semantic-release/npm@12` to `extra_plugins` in the release workflow
- The bundled npm plugin in `cycjimmy/semantic-release-action@v6` doesn't pass `--provenance` to `npm publish`, so OIDC token exchange never happens
- Without OIDC auth, npm returns 404 for the scoped `@expediagroup` package

## Context
Follows up on PR #386. The action worked (passed token validation) but the actual publish failed with E404 because no auth token was present during `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)