### PR TITLE
fix(release): use direct npm publish with OIDC instead of @semantic-release/npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,15 +38,6 @@ jobs:
         run: npm run build && cd dist && ls -la
 
       - name: Release
-        uses: cycjimmy/semantic-release-action@v6
-        with:
-          working_directory: dist
-          extra_plugins: |
-            @semantic-release/npm@12
-            @semantic-release/changelog@6
-            @semantic-release/git@10
-            @semantic-release/exec@7
-            conventional-changelog-conventionalcommits@9
         env:
           GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
@@ -54,3 +45,6 @@ jobs:
           GIT_AUTHOR_EMAIL: oss@expediagroup.com
           GIT_COMMITTER_NAME: eg-oss-ci
           GIT_COMMITTER_EMAIL: oss@expediagroup.com
+        run: |
+          cd dist
+          npx semantic-release --debug

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -58,14 +58,15 @@
         "changelogFile": "CHANGELOG.md"
       }
     ],
-    ["@semantic-release/npm", { "provenance": true }],
-    "@semantic-release/github",
     [
       "@semantic-release/exec",
       {
+        "prepareCmd": "npm version ${nextRelease.version} --no-git-tag-version --allow-same-version",
+        "publishCmd": "npm publish --provenance --access public",
         "successCmd": "sh ../scripts/update-assets.sh"
       }
     ],
+    "@semantic-release/github",
     [
       "@semantic-release/git",
       {


### PR DESCRIPTION
## Summary
- Removes `@semantic-release/npm` plugin which creates its own `.npmrc` that overrides npm's native OIDC trusted publishing flow
- Replaces it with `@semantic-release/exec` running `npm publish --provenance --access public` directly
- Drops `cycjimmy/semantic-release-action` in favor of direct `npx semantic-release` to avoid bundled plugin version conflicts

## Why previous attempts failed
| PR | Error | Root cause |
|----|-------|------------|
| #385 | EINVALIDNPMTOKEN | `.npmrc` placeholder token failed validation |
| #386 | E404 | Action's bundled npm plugin published without OIDC auth |
| #388 | ENEEDAUTH | extra_plugins didn't override bundled npm plugin |

All failures trace back to `@semantic-release/npm` creating a temp `.npmrc` that intercepts npm's native OIDC flow.

## How this fix works
`npm publish --provenance` triggers npm CLI to:
1. Request an OIDC token from GitHub Actions runtime (`id-token: write` permission)
2. Exchange it with npmjs.org via trusted publishing config
3. Publish the package - no static token needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)