### PR TITLE
fix(release): use setup-node v6 with registry-url for OIDC npm auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,10 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "latest"
+          registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
         run: npm install

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -58,15 +58,14 @@
         "changelogFile": "CHANGELOG.md"
       }
     ],
+    "@semantic-release/npm",
+    "@semantic-release/github",
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "npm version ${nextRelease.version} --no-git-tag-version --allow-same-version",
-        "publishCmd": "npm publish --provenance --access public",
         "successCmd": "sh ../scripts/update-assets.sh"
       }
     ],
-    "@semantic-release/github",
     [
       "@semantic-release/git",
       {


### PR DESCRIPTION
## Summary
- Upgrades `actions/setup-node` from v4 to v6
- Adds `registry-url: https://registry.npmjs.org/` to setup-node config
- Reverts `.releaserc.json` to use `@semantic-release/npm` (plain, no provenance hack)

## Why this works
Matches the pattern used by other EG OSS packages (e.g. [graphql-component#115](https://github.com/ExpediaGroup/graphql-component/pull/115)):
- `setup-node@v6` + `registry-url` + `id-token: write` = OIDC-based npm auth
- No npm token needed

## Previous attempts
All prior PRs (#385-389) failed because we were missing the `registry-url` config on `setup-node`, which is what actually enables OIDC auth for npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)