### PR TITLE
fix(release): use exec plugin for npm publish to bypass token validation

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -58,14 +58,15 @@
         "changelogFile": "CHANGELOG.md"
       }
     ],
-    "@semantic-release/npm",
-    "@semantic-release/github",
     [
       "@semantic-release/exec",
       {
+        "prepareCmd": "npm version ${nextRelease.version} --no-git-tag-version --allow-same-version",
+        "publishCmd": "npm publish --access public",
         "successCmd": "sh ../scripts/update-assets.sh"
       }
     ],
+    "@semantic-release/github",
     [
       "@semantic-release/git",
       {


### PR DESCRIPTION
## Summary
- Replaces `@semantic-release/npm` with `@semantic-release/exec` for npm publishing
- `@semantic-release/npm` validates tokens in `verifyConditions` before publish, but `setup-node@v6` OIDC auth only works at actual `npm publish` time
- `@semantic-release/exec` calls `npm publish --access public` directly, letting setup-node's OIDC handle auth

Follows up on PR #390 which added `setup-node@v6` with `registry-url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)