### PR TITLE
fix(release): stop overriding GITHUB_TOKEN to preserve OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Release
         env:
           GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           GIT_AUTHOR_NAME: eg-oss-ci
           GIT_AUTHOR_EMAIL: oss@expediagroup.com
           GIT_COMMITTER_NAME: eg-oss-ci


### PR DESCRIPTION
## Summary
- Removes `GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}` from Release step
- Keeps `GH_TOKEN` for semantic-release git/GitHub operations (branch protection bypass)
- Lets the default runtime `GITHUB_TOKEN` handle npm OIDC token exchange

## Why
Overriding `GITHUB_TOKEN` with a PAT breaks npm's OIDC flow - PATs don't have OIDC capabilities. The default Actions runtime token is needed for OIDC.