### PR TITLE
fix(release): match proven trusted publishing pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,27 +5,22 @@ on:
       - main
       - test
 
+permissions: write-all
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-      id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: "latest"
-          registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
         run: npm install
@@ -39,12 +34,18 @@ jobs:
         run: npm run build && cd dist && ls -la
 
       - name: Release
+        uses: cycjimmy/semantic-release-action@v6
+        with:
+          working_directory: dist
+          extra_plugins: |
+            @semantic-release/changelog@6
+            @semantic-release/git@10
+            @semantic-release/exec@7
+            conventional-changelog-conventionalcommits@9
         env:
           GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: eg-oss-ci
           GIT_AUTHOR_EMAIL: oss@expediagroup.com
           GIT_COMMITTER_NAME: eg-oss-ci
           GIT_COMMITTER_EMAIL: oss@expediagroup.com
-        run: |
-          cd dist
-          npx semantic-release --debug

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -58,15 +58,14 @@
         "changelogFile": "CHANGELOG.md"
       }
     ],
+    "@semantic-release/npm",
+    "@semantic-release/github",
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "npm version ${nextRelease.version} --no-git-tag-version --allow-same-version",
-        "publishCmd": "npm publish --access public",
         "successCmd": "sh ../scripts/update-assets.sh"
       }
     ],
-    "@semantic-release/github",
     [
       "@semantic-release/git",
       {


### PR DESCRIPTION
## Summary
Matches the exact working pattern from `graphql-kotlin-codegen`:
- `permissions: write-all` at workflow level
- `cycjimmy/semantic-release-action@v6` (handles npm OIDC internally)
- `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` (built-in runtime token for OIDC)
- `GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}` (for git push past branch protection)
- `@semantic-release/npm` in `.releaserc.json` (action bundles compatible version)
