### PR TITLE
fix(release): add persist-credentials: false for git push auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
Adds `persist-credentials: false` to checkout so `@semantic-release/git` uses `GH_TOKEN` (PAT) for git push instead of the built-in `GITHUB_TOKEN` which can't bypass branch protection.

Follows PR #394 where npm publish succeeded but git push failed with GH006.
