### PR TITLE
fix(release): use npm trusted publishing (OIDC)

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -52,7 +52,7 @@
         }
       }
     ],
-    "@semantic-release/npm",
+    ["@semantic-release/npm", { "provenance": true }],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary

- Enable `provenance: true` on `@semantic-release/npm` for OIDC authentication

## Problem

After #399, `@semantic-release/npm` still fails with `ENEEDAUTH` because it creates a temp `.npmrc` with no auth token. Without `provenance: true`, npm doesn't know to use OIDC token exchange for authentication.

## Solution

Add `provenance: true` to the npm plugin config. This makes `npm publish` request an OIDC token from GitHub Actions and authenticate via npmjs.org trusted publishing. We already have `permissions: write-all` which includes `id-token: write` needed for this.

## Test plan

- [ ] Merge to `main` and verify the release workflow publishes to npmjs.org
- [ ] Verify GitHub Release is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)