### PR TITLE
fix: Restore cli bin to undo breaking change in #402

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "bin": {
+    "cli": "cli.js",
     "spec-transformer": "cli.js"
   },
   "scripts": {


### PR DESCRIPTION
# Situation
Changes in #402 removed the bin for cli, which was a breaking change

# Task
Restore the cli bin so that npx executions prior to #402 still work

# Testing
Manually verified locally that both the cli bin options and the default spec-transformer bin work.

